### PR TITLE
ci(dependabot): ignore parallel semver-major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
   - dependency-type: direct
   - dependency-type: indirect
   ignore:
+  - dependency-name: parallel
+    update-types: ["version-update:semver-major"]
   - dependency-name: codecov
     versions:
     - ">= 0.2.14.a, < 0.2.15"


### PR DESCRIPTION
## Summary
- parallel >= 2.0 requires Ruby >= 3.3, but our CI matrix still includes Ruby 3.2.8
- Dependabot's resolver crashes on every run while trying to bump parallel from 1.28.0, blocking all other dependency PRs
- Add a `version-update:semver-major` ignore so Dependabot stops trying

Closes unhappychoice/oss-issue-opener#228

## Test plan
- [ ] Next Dependabot run completes without the parallel resolver crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automatic dependency update settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->